### PR TITLE
use loopback as api address until have stable release

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -79,7 +79,7 @@ const CONFIG = {
   aoc: {
     year: parsePositiveInt(process.env[envOptions.year], new Date().getFullYear()),
     authenticationToken: process.env[envOptions.authenticationToken] || null,
-    baseUrl: 'https://adventofcode.com',
+    baseUrl: 'http://192.168.0.1', // 'https://adventofcode.com',
     userAgent:
       'https://github.com/beakerandjake/advent-of-code-runner by beakerandjake',
     responseParsing: {


### PR DESCRIPTION
Anyone that clones this repo or uses this package in its alpha state can actually hit the advent of code api. To prevent that from happening until this package is stable, i've updated the config to hit the loopback address instead of the real api.