### PR TITLE
Feature/200 improve local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,4 @@ dist
 .DS_Store
 
 # ignore local development folder
-dev/
+development/

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "eslint": "^8.29.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.26.0",
-        "jest": "^29.3.1"
+        "jest": "^29.3.1",
+        "mkdirp": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -5506,6 +5507,21 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.3.tgz",
+      "integrity": "sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -11193,6 +11209,12 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.3.tgz",
+      "integrity": "sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "bin": "src/main.js",
   "scripts": {
     "test": "NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest",
-    "start": "node src/main.js",
+    "start": "mkdirp development && cd development && node ../src/main.js",
     "lint": "eslint 'src/**/*.js' 'tests/**/*.js'"
   },
   "repository": {
@@ -55,7 +55,8 @@
     "eslint": "^8.29.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "jest": "^29.3.1"
+    "jest": "^29.3.1",
+    "mkdirp": "^2.1.3"
   },
   "engines": {
     "node": ">=18"

--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,6 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 dotenv.config();
 
 export const envOptions = {
-  cwdOverride: 'AOC_CWD_OVERRIDE',
   suppressTitle: 'AOC_SUPPRESS_TITLE',
   suppressFestive: 'AOC_SUPPRESS_FESTIVE',
   authenticationToken: 'AOC_AUTHENTICATION_TOKEN',
@@ -31,7 +30,7 @@ export const envOptions = {
  * This will be the root folder where this program operates.
  * User solution files, inputs, data store etc will all exist in this folder.
  */
-const cwd = process.env[envOptions.cwdOverride] || getCwd();
+const cwd = getCwd();
 
 /**
  * Load meta details about this package form the package json

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,12 @@ import { get, has } from './util.js';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 // ensure dotenv runs before we attempt to read any environment variables.
+
+// read the users config from the cwd.
 dotenv.config();
+
+// allow overrides by reading from 'development' .env (if exists)
+dotenv.config({ path: join(__dirname, '..', '.env') });
 
 export const envOptions = {
   suppressTitle: 'AOC_SUPPRESS_TITLE',

--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,8 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 // read the users config from the cwd.
 dotenv.config();
 
-// allow overrides by reading from 'development' .env (if exists)
+// attempt to read an .env file at the root of this repository.
+// this helps in local development by having one place to set development settings.
 dotenv.config({ path: join(__dirname, '..', '.env') });
 
 export const envOptions = {


### PR DESCRIPTION
- Rename local workspace from `dev` to `development`
  - Update `.gitignore` to ignore this fodler

- Update `npm start`
  - Create local workspace folder if doesn't exist
  - Explicitly change the cwd to local workspace folder

- `config.js` will try to load `.env` from root of project for local development. 

All of these changes make local development easier. The `AOC_CWD_OVERRIDE` option is removed and instead `npm start` just sets cwd before running `main.js`. This way no override is required. 