### PR TITLE
Update config to support 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated configuration to support 2024. ([#246](https://github.com/beakerandjake/advent-of-code-runner/issues/247))
 
 ## [1.7.1] - 2023-12-28
 ### Fixed

--- a/src/config.js
+++ b/src/config.js
@@ -78,7 +78,7 @@ const CONFIG = {
       // also allows possibility that aoc doesn't run during a specific year.
       // also ensures that this package gets updates at least once a year to support
       // that years aoc and any changes that might be needed.
-      years: [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023],
+      years: [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024],
       days: [...Array(25).keys()].map((x) => x + 1), // 1-25 expected to always be advent calendar..
       levels: [1, 2],
     },


### PR DESCRIPTION
I though that having the years explicitly set in configuration was a good idea, but it might make more sense to be automatic? 